### PR TITLE
Don't double-reply to reviews

### DIFF
--- a/src/github.rs
+++ b/src/github.rs
@@ -81,10 +81,10 @@ pub struct RepliedReview {
 }
 
 impl From<NonRepliedReview> for RepliedReview {
-    fn from(missing_email: NonRepliedReview) -> Self {
+    fn from(review: NonRepliedReview) -> Self {
         Self {
-            pr: missing_email.pr,
-            reviewer: missing_email.reviewer,
+            pr: review.pr,
+            reviewer: review.reviewer,
         }
     }
 }


### PR DESCRIPTION
Fixes a bug caused when a reviewer approves a PR twice in one "check interval".